### PR TITLE
Remove the update channel from the manifest

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,8 +2,7 @@
   "applications": {
     "gecko": {
       "id": "mdndoclinter@mdn.org",
-      "strict_min_version": "54.0a1",
-      "update_url": "https://mdn.github.io/doc-linter-webextension/updates.json"
+      "strict_min_version": "54.0a1"
     }
   },
   "background": {


### PR DESCRIPTION
Remove the update channel from the manifest because it's incompatible with the process used with addons.mozilla.org