### PR TITLE
Add "eventref" to the list of allowed macros

### DIFF
--- a/add-on/rules.js
+++ b/add-on/rules.js
@@ -841,6 +841,7 @@ exports.invalidMacros = {
       "embedlivesample",
       "embedyoutube",
       "event",
+      "eventref",
       "experimental_inline",
       "firefox_for_developers",
       "fx_minversion_inline",


### PR DESCRIPTION
The event reference pages generate their sidebar using the
`{{EventRef}}` macro, which was missing from the allowed macros
list. This patch adds it.